### PR TITLE
fix DecentsWayOff bug on multipage Eval Summary

### DIFF
--- a/BGAnimations/ScreenEvaluationSummary overlay/stageStats.lua
+++ b/BGAnimations/ScreenEvaluationSummary overlay/stageStats.lua
@@ -217,6 +217,8 @@ for player in ivalues(Players) do
 						self:visible(false)
 					elseif DecentsWayOffs == "Off" and (i == 4 or i == 5) then
 						self:visible(false)
+					else
+						self:visible(true)
 					end
 
 				else


### PR DESCRIPTION
It's possible for players to change the DecentsWayOffs settings from song to song.  There was previously a bug in the ScreenEvaluationSummary code where the numbers for Decents and numbers for WayOffs would stay hidden once `visible(false)` was set.  This was problematic for multipage EvaluationSummaries as Bran recently discovered during a livestream.

This change ensures that the BitmapText actors for the numbers are appropriately reset to `visible(true)` every time the player switches from one page of scores to another.