### PR TITLE
reinstate lost changes from Dec2018 and Jan2019

### DIFF
--- a/BGAnimations/ScreenEvaluationStage in/default.lua
+++ b/BGAnimations/ScreenEvaluationStage in/default.lua
@@ -1,48 +1,22 @@
-local statsP1 = STATSMAN:GetCurStageStats():GetPlayerStageStats(PLAYER_1);
-local statsP2 = STATSMAN:GetCurStageStats():GetPlayerStageStats(PLAYER_2);
+-- assume that all human players failed
+local img = "failed text.png"
 
-local gradeP1 = statsP1:GetGrade();
-local gradeP2 = statsP2:GetGrade();
-
-local function failed(g)
-	if g == "Grade_Failed" then
-		return true;
-	else
-		return false;
+-- loop through all available human players
+for player in ivalues(GAMESTATE:GetHumanPlayers()) do
+	-- if any of them passed, we want to display the "cleared" graphic
+	if not STATSMAN:GetCurStageStats():GetPlayerStageStats(player):GetFailed() then
+		img = "cleared text.png"
 	end
 end
 
-
-local img = "cleared text.png"
-
--- if (only P1) and (P1 failed)
-if (GAMESTATE:IsHumanPlayer(PLAYER_1) and failed(gradeP1) and not GAMESTATE:IsHumanPlayer(PLAYER_2)) then
-	img = "failed text.png"
-	
--- if (only P2) and (P2 failed)	
-elseif (GAMESTATE:IsHumanPlayer(PLAYER_2) and failed(gradeP2) and not GAMESTATE:IsHumanPlayer(PLAYER_1)) then
-	img = "failed text.png"
-
--- if (both P1 and P2) and (both P1 and P2 failed)	
-elseif (GAMESTATE:IsHumanPlayer(PLAYER_1) and GAMESTATE:IsHumanPlayer(PLAYER_2) and failed(gradeP1) and failed(gradeP2) ) then
-	img = "failed text.png"
-	
-end
-
-
-local t = Def.ActorFrame {
-	InitCommand=cmd(xy,_screen.cx, _screen.cy);
-	
+return Def.ActorFrame {
 	Def.Quad{
-		InitCommand=cmd(zoomto,_screen.w,_screen.h; diffuse,color("0,0,0,1"););
-		OnCommand=cmd(sleep,0.2; linear,0.5;  diffusealpha,0);
-	};
-	
-	LoadActor(img)..{
-		InitCommand=cmd(zoom,0.8; diffusealpha,0;);
-		OnCommand=cmd(accelerate,0.4;diffusealpha,1; sleep,1.3; decelerate,0.4;diffusealpha,0);
-	}
-	
-};
+		InitCommand=cmd(FullScreen; diffuse, Color.Black),
+		OnCommand=cmd(sleep,0.2; linear,0.5; diffusealpha,0),
+	},
 
-return t;
+	LoadActor(img)..{
+		InitCommand=cmd(Center; zoom,0.8; diffusealpha,0),
+		OnCommand=cmd(accelerate,0.4; diffusealpha,1; sleep,0.6; decelerate,0.4; diffusealpha,0)
+	}
+}

--- a/BGAnimations/ScreenGameOver overlay/PlayerStatsWithoutProfile.lua
+++ b/BGAnimations/ScreenGameOver overlay/PlayerStatsWithoutProfile.lua
@@ -1,10 +1,8 @@
 local player = ...
 
-local stageStats = STATSMAN:GetCurStageStats()
-local currentCombo = stageStats:GetPlayerStageStats(player):GetCurrentCombo()
-
 local totalTime = 0
 local songsPlayedThisGame = 0
+local notesHitThisGame = 0
 
 -- Use pairs here (instead of ipairs) because this player might have late-joined
 -- which will result in nil entries in the the Stats table, which halts ipairs.
@@ -12,6 +10,21 @@ local songsPlayedThisGame = 0
 for i,stats in pairs( SL[ToEnumShortString(player)].Stages.Stats ) do
 	totalTime = totalTime + (stats and stats.duration or 0)
 	songsPlayedThisGame = songsPlayedThisGame + (stats and 1 or 0)
+
+	if stats and stats.column_judgments then
+		-- increment notesHitThisGame by the total number of tapnotes hit in this particular stepchart by using the per-column data
+		-- don't rely on the engine's non-Miss judgment counts here for two reasons:
+		-- 1. we want jumps/hands to count as more than 1 here
+		-- 2. stepcharts can have non-1 #COMBOS parameters set which would artbitraily inflate notesHitThisGame
+
+		for column, judgments in ipairs(stats.column_judgments) do
+			for judgment, judgment_count in pairs(judgments) do
+				if judgment ~= "Miss" then
+					notesHitThisGame = notesHitThisGame + judgment_count
+				end
+			end
+		end
+	end
 end
 
 local hours = math.floor(totalTime/3600)
@@ -19,9 +32,9 @@ local minutes = math.floor((totalTime-(hours*3600))/60)
 local seconds = round(totalTime%60)
 
 local lines = {
-	ScreenString("CurrentCombo") .. "\n"..currentCombo,
-	ScreenString("SongsPlayedThisGame") .. "\n"..songsPlayedThisGame,
-	ScreenString("TimeSpentThisGame") .. "\n".. minutes .. THEME:GetString("ScreenGameOver", "Minutes") .. " " .. seconds .. THEME:GetString("ScreenGameOver", "Seconds")
+	ScreenString("SongsPlayedThisGame") .. "\n" .. songsPlayedThisGame,
+	ScreenString("NotesHitThisGame") .. "\n" .. notesHitThisGame,
+	ScreenString("TimeSpentThisGame") .. "\n" .. minutes .. THEME:GetString("ScreenGameOver", "Minutes") .. " " .. seconds .. THEME:GetString("ScreenGameOver", "Seconds")
 }
 
 -- assume above that the gameplay session was < 1 hour, but check now

--- a/BGAnimations/ScreenSelectMusic overlay/PerPlayer/PaneDisplay.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/PerPlayer/PaneDisplay.lua
@@ -171,7 +171,7 @@ local pd = Def.ActorFrame{
 			local player_score, player_name = GetNameAndScore( PROFILEMAN:GetProfile(player) )
 
 			self:GetChild("PlayerHighScore"):settext(player_score)
-			self:GetChild("PlayerHighScoreName"):settext(player_name):diffuse({0,0,0,0})
+			self:GetChild("PlayerHighScoreName"):settext(player_name):diffuse({0,0,0,1})
 
 			for i=1, player_name:utf8len() do
 				if player_name:utf8sub(i,i):byte() >= 240 then

--- a/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/SortMenu/default.lua
@@ -52,7 +52,7 @@ local t = Def.ActorFrame {
 
 		-- Allow players to switch from single to double and from double to single
 		-- but only present these options if Joint Double or Joint Premium is enabled
-		if PREFSMAN:GetPreference("Premium") ~= "Premium_Off" then
+		if not (PREFSMAN:GetPreference("Premium") == "Premium_Off" and GAMESTATE:GetCoinMode() == "CoinMode_Pay") then
 			if SL.Global.Gamestate.Style == "single" then
 				table.insert(wheel_options, {"ChangeStyle", "Double"})
 			elseif SL.Global.Gamestate.Style == "double" then

--- a/BGAnimations/ScreenSelectMusic overlay/songDescription.lua
+++ b/BGAnimations/ScreenSelectMusic overlay/songDescription.lua
@@ -1,3 +1,27 @@
+-- before loading actors, pre-calculate each group's overall duration by
+-- looping through its songs and summing their duration
+-- store each group's overall duration in a lookup table, keyed by group_name
+-- to be retrieved + displayed when actively hovering on a group (not a song)
+--
+-- I haven't checked, but I assume that continually recalculating group durations could
+-- have performance ramifications when rapidly scrolling through the MusicWheel
+--
+-- a consequence of pre-calculating and storing the group_durations like this is that
+-- live-reloading a song on ScreenSelectMusic via Control R might cause the group duration
+-- to then be inaccurate, until the screen is reloaded.
+
+local group_durations = {}
+
+for _,group_name in ipairs(SONGMAN:GetSongGroupNames()) do
+	group_durations[group_name] = 0
+
+	for _,song in ipairs(SONGMAN:GetSongsInGroup(group_name)) do
+		group_durations[group_name] = group_durations[group_name] + song:MusicLengthSeconds()
+	end
+end
+
+-- ----------------------------------------
+
 local t = Def.ActorFrame{
 
 	OnCommand=function(self)
@@ -112,6 +136,11 @@ local t = Def.ActorFrame{
 						local song = GAMESTATE:GetCurrentSong()
 						if song then
 							duration = song:MusicLengthSeconds()
+						else
+							local group_name = SCREENMAN:GetTopScreen():GetMusicWheel():GetSelectedSection()
+							if group_name then
+								duration = group_durations[group_name]
+							end
 						end
 					end
 

--- a/Graphics/Player combo.lua
+++ b/Graphics/Player combo.lua
@@ -1,67 +1,25 @@
 local player = Var "Player"
 
-if SL[ToEnumShortString(player)].ActiveModifiers.HideCombo then return end
-
-local kids
+if SL[ToEnumShortString(player)].ActiveModifiers.HideCombo then
+	return Def.Actor{ InitCommand=function(self) self:visible(false) end }
+end
 
 local ShowComboAt = THEME:GetMetric("Combo", "ShowComboAt")
-local NumberMinZoom = 0.75
-local NumberMaxZoom = 1.1
-local NumberMaxZoomAt = tonumber(THEME:GetMetric("Combo", "NumberMaxZoomAt"))
 
 return Def.ActorFrame {
 
 	InitCommand=function(self)
 		self:draworder(101)
-		kids = self:GetChildren()
 	end,
 	OnCommand=function(self)
-		if SL.Global.GameMode == "StomperZ" then
-			self:y(-20)
-		end
+		if SL.Global.GameMode == "StomperZ" then self:y(-20) end
 	end,
 
-	ComboCommand=function(self, param)
-		local CurrentCombo = param.Misses or param.Combo
+	ComboCommand=function(self, params)
+		local CurrentCombo = params.Misses or params.Combo
 
-		if not CurrentCombo or CurrentCombo < ShowComboAt then
-			-- the combo isn't high enough to display, so hide the AF
-			self:visible( false )
-			return
-		end
-
-		-- the combo has reached (or surpassed) the threshold to be shown
-		if CurrentCombo >= ShowComboAt then
-			-- so, display the AF
-			self:visible( true )
-		end
-
-		if CurrentCombo <= NumberMaxZoomAt then
-			kids.Number:zoom( scale( CurrentCombo, 0, NumberMaxZoomAt, NumberMinZoom, NumberMaxZoom ) )
-		end
-		kids.Number:settext( CurrentCombo )
-
-
-		if (SL.Global.GameMode ~= "ECFA" and param.FullComboW1) or (SL.Global.GameMode == "ECFA" and (param.FullComboW1 or param.FullComboW2)) then
-			-- blue combo
-			kids.Number:playcommand("ChangeColor", {Color1="#C8FFFF", Color2="#6BF0FF"})
-
-		elseif (SL.Global.GameMode ~= "ECFA" and param.FullComboW2) or (SL.Global.GameMode == "ECFA" and param.FullComboW3) then
-			-- gold combo
-			kids.Number:playcommand("ChangeColor", {Color1="#FDFFC9", Color2="#FDDB85"})
-
-		elseif (SL.Global.GameMode ~= "ECFA" and param.FullComboW3) or (SL.Global.GameMode == "ECFA" and param.FullComboW4) then
-			-- green combo
-			kids.Number:playcommand("ChangeColor", {Color1="#C9FFC9", Color2="#94FEC1"})
-
-		elseif param.Combo then
-			-- normal (white) combo
-			kids.Number:stopeffect():diffuse( Color.White )
-
-		else
-			-- miss (red) combo
-			kids.Number:stopeffect():diffuse( Color.Red )
-		end
+		-- if the combo has reached (or surpassed) the threshold to be shown, display the AF, otherwise hide it
+		self:visible( CurrentCombo ~= nil and CurrentCombo >= ShowComboAt )
 	end,
 
 	-- load the milestones actors now and trigger them to display
@@ -80,7 +38,32 @@ return Def.ActorFrame {
 	LoadFont("_wendy combo")..{
 		Name="Number",
 		OnCommand=function(self)
-			self:shadowlength(1):vertalign(middle)
+			self:shadowlength(1):vertalign(middle):zoom(0.75)
+		end,
+		ComboCommand=function(self, params)
+			local CurrentCombo = params.Misses or params.Combo
+			self:settext( CurrentCombo or "" )
+
+			if (SL.Global.GameMode ~= "ECFA" and params.FullComboW1) or (SL.Global.GameMode == "ECFA" and (params.FullComboW1 or params.FullComboW2)) then
+				-- blue combo
+				self:playcommand("ChangeColor", {Color1="#C8FFFF", Color2="#6BF0FF"})
+
+			elseif (SL.Global.GameMode ~= "ECFA" and params.FullComboW2) or (SL.Global.GameMode == "ECFA" and params.FullComboW3) then
+				-- gold combo
+				self:playcommand("ChangeColor", {Color1="#FDFFC9", Color2="#FDDB85"})
+
+			elseif (SL.Global.GameMode ~= "ECFA" and params.FullComboW3) or (SL.Global.GameMode == "ECFA" and params.FullComboW4) then
+				-- green combo
+				self:playcommand("ChangeColor", {Color1="#C9FFC9", Color2="#94FEC1"})
+
+			elseif params.Combo then
+				-- normal (white) combo
+				self:stopeffect():diffuse( Color.White )
+
+			else
+				-- miss (red) combo
+				self:stopeffect():diffuse( Color.Red )
+			end
 		end,
 		ChangeColorCommand=function(self, params)
 			self:diffuseshift():effectperiod(0.8)

--- a/Graphics/Player judgment.lua
+++ b/Graphics/Player judgment.lua
@@ -15,7 +15,9 @@ if not FindInTable(wanted_graphics, graphics) then
 	wanted_graphics = graphics[1] or "None"
 end
 
-if wanted_graphics == "None" then return end
+if wanted_graphics == "None" then
+	return Def.Actor{ InitCommand=function(self) self:visible(false) end }
+end
 
 -- - - - - - - - - - - - - - - - - - - - - -
 

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -214,9 +214,9 @@ FormatStages=%i Stages
 [ScreenGameOver]
 LastUsedHighScoreName=High Score Name
 CaloriesBurned=Calories Burned
-CurrentCombo=Current Combo
 TotalSongsPlayed=Total Songs Played
 SongsPlayedThisGame=Songs Played This Game
+NotesHitThisGame=Notes Hit This Game
 TimeSpentThisGame=Time Spent This Game
 Hours=hr.
 Minutes=min.
@@ -402,6 +402,7 @@ USB Custom Songs Options=♥  USB Custom Songs Options
 Set BG Fit Mode=♥  Set Background Fit
 Input Options=♥  Input Options
 Acknowledgments=♥  Acknowledgments
+Clear Credits=♥  Clear Credits
 
 # System Options
 Editor Noteskin=Editor Noteskin
@@ -503,6 +504,8 @@ USB Custom Songs Options=Adjust settings related to USB Custom Songs, including 
 MenuTimer Options=Turn the MenuTimer On or Off and set the MenuTimer values for various screens.
 Input Options=Adjust input options such as joystick automapping, dedicated menu buttons, and input debounce.
 Acknowledgments=View acknowledgments and credits for Simply Love, StepMania, and more.
+Clear Credits=Reset coin credits to 0.
+
 
 # System Options
 Game=Change the current game type.\n\n• dance is 4-panel (DDR and ITG).\n\n• pump is 5-panel (Pump It Up).\n\n• techno is 8-panel (TechnoMotion).\n\nOther game types (kickbox, para, beat, etc.) may not actually be supported.

--- a/Languages/es.ini
+++ b/Languages/es.ini
@@ -620,6 +620,7 @@ USB Custom Songs Options=Cambia ajustes relacionados con canciones adicionales d
 MenuTimer Options=Enciende o apaga el tiempo de menu y ajusta los valores para varias pantallas.
 Input Options=Ajusta opciones de controladores como el Auto mapeado de joysticks, botones de menú dedicados y arreglo de mapeo.
 Acknowledgments=Ve los reconocimientos y creditos para Simply Love, StepMania, y más.
+Clear Credits=Borrar todos los créditos.
 
 # System Options
 Game=Cambia el modo de juego.\n\n• dance es 4 paneles (DDR y ITG).\n\n• pump es 5 paneles (Pump It Up).\n\n• techno es 8 paneles (TechnoMotion).\n\nOtros modos de juego (kickbox, para, beat, etc.) probablemente no son soportados.

--- a/Languages/fr.ini
+++ b/Languages/fr.ini
@@ -523,6 +523,7 @@ Profiles=Modifier les profils locaux de joueurs sur cette machine.
 Graphics/Sound Options=Modifier la résolution, le mode plein écran, et les options de sons.
 Test Input=Tester les entrées des contrôleurs connectés.
 Key Joy Mappings=Assigner les touches et boutons de joystick à des fonctions de jeu.
+Clear Credits=Effacer tous les crédits.
 
 # System Options
 Game=Changer le type de jeu actuel.\n\n• dance = 4 touches (DDR et ITG).\n\n• pump = 5 touches (Pump It Up).\n\n• techno = 8 touches (TechnoMotion).\n\nLes autres modes de jeux (kickbox, para, beat, etc.) peuvent présenter des soucis et ne pas être supportés.

--- a/Languages/pt-br.ini
+++ b/Languages/pt-br.ini
@@ -766,7 +766,7 @@ HoldRolls=Pressionar Rolos
 NextRow=&NEXTROW;
 Animations=Animações Aleatórias
 Random Movies=Filmes Aleatórios
-# HACK? 
+# HACK?
 # Ok, now the above comment is out of context because i've fucked the fallback transltions order, thanks me ~Zerinho6
 On (recommended)=Ativado
 Blender=Mixer
@@ -1482,19 +1482,19 @@ MusicRate=Altere a velocidade da música.
 ScreenAfterPlayerOptions=Escolha outra música OU selecione mais modificadores.
 
 # ScreenPlayerOptions2
-Accel=Estilos de aceleração. 
-Effect=Vários efeitos de flecha. 
-Appearance=Controla a visibilidade das notas. 
-Turn=Altere as notas do Stepchart. 
+Accel=Estilos de aceleração.
+Effect=Vários efeitos de flecha.
+Appearance=Controla a visibilidade das notas.
+Turn=Altere as notas do Stepchart.
 #'
-Insert=Inserir mais notas 
-Scroll=Alterar como as notas se movem. 
+Insert=Inserir mais notas
+Scroll=Alterar como as notas se movem.
 NoteSkin=Altere a aparência das notas.
-Holds=Modifique as pressões. 
+Holds=Modifique as pressões.
 Mines=Modifique as minas.
 Attacks=Ative ou desative os modificadores atribuídos.\n"Ataques Aleatorios" irá aplicar modificadores aleatórios.
 PlayerAutoPlay=Ative a reprodução automática.
-Hide=Esconda vários elementos do jogo. 
+Hide=Esconda vários elementos do jogo.
 Persp=Altere a perspectiva da área do jogo.
 Remove=Excluir notas.
 TargetStatus=Mostrar o gráfico de pontuação\nou as estatísticas de notas ao lado da área de jogo.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Simply Love has full support for:
   * English
   * Español
   * Français
+  * Português Brasileiro
 
 The current language can be changed in Simply Love under *System Options*.  You may need to restart StepMania immediately after changing the language for all in-game text to be properly translated.
 

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -156,7 +156,14 @@ function SetGameModePreferences()
 end
 
 function GetOperatorMenuLineNames()
-	local lines = "System,KeyConfig,TestInput,Visual,GraphicsSound,Arcade,Input,Theme,MenuTimer,CustomSongs,Advanced,Profiles,Acknowledgments,Reload"
+	local lines = "System,KeyConfig,TestInput,Visual,GraphicsSound,Arcade,Input,Theme,MenuTimer,CustomSongs,Advanced,Profiles,Acknowledgments,ClearCredits,Reload"
+
+
+	-- hide the OptionRow for ClearCredits if we're not in CoinMode_Pay; it doesn't make sense to show for at-home players
+	-- note that (EventMode + CoinMode_Pay) will actually place you in CoinMode_Home
+	if GAMESTATE:GetCoinMode() ~= "CoinMode_Pay" then
+		lines = lines:gsub("ClearCredits,", "")
+	end
 
 	-- CustomSongs preferences don't exist in 5.0.x, which many players may still be using
 	-- thus, if the preference for CustomSongsEnable isn't found in this version of SM, don't let players

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -207,7 +207,7 @@ local Overrides = {
 			list[3] = mods.HideCombo 	or false
 			list[4] = mods.HideLifebar 	or false
 			list[5] = mods.HideScore 	or false
-			list[6] = mods.HideDanger	or true
+			list[6] = mods.HideDanger	or false
 			return list
 		end,
 		SaveSelections = function(self, list, pn)

--- a/metrics.ini
+++ b/metrics.ini
@@ -820,6 +820,7 @@ LineMenuTimer="gamecommand;screen,ScreenMenuTimerOptions;name,MenuTimer Options"
 LineCustomSongs="gamecommand;screen,ScreenCustomSongsOptions;name,USB Custom Songs Options"
 LineAdvanced="gamecommand;screen,ScreenOptionsAdvanced;name,Advanced Options"
 LineProfiles="gamecommand;screen,ScreenOptionsManageProfiles;name,Profiles"
+LineClearCredits="gamecommand;clearcredits;name,Clear Credits"
 LineAcknowledgments="gamecommand;screen,ScreenAcknowledgmentsMenu;name,Acknowledgments"
 
 ExplanationTogetherY=_screen.cy+180


### PR DESCRIPTION
Commit 6756226b259f96d54a3826ba544f5b8e02cfa085 made some QR code improvements and merged the oversensitive-pads branch with the master branch.  The latter decision inadvertently undid all changes that had been committed between 15 December 2018 and 17 January 2019, making that single commit really do three distinct things.

I suppose it would have been possible to just revert 6756226b259f96d54a3826ba544f5b8e02cfa085 and bring in the QR changes in one commit and then (I guess) cherry-pick the few relevant commits out of the oversensitive-pads branch, but that didn't seem to be getting done, so I'm resolving this by manually bringing back all the lost changes.

To clarify, this pull request does not bring back *every* commit from the aforementioned date range;  some were later properly superseded by commits from @teejusb.

This pull request does bring back changes made in:
43a9268dbd00b3461f1168b40f44e726f5607f21
8905015c0857295bf2e620af81ca3f7b41a393cf
6cedcae88a120f7026fda2aa6d64cecc0967a53c
58f50e1a5296c746c90412510ba18f46384d8870
32d742840dea9492b4bcbc0aa98395ab52899033
f49930d1e54fa6d5843e196b851b72c75e1b27c8
bd03fba86bfbae5e800c6caf1e94ae8897b43cdd
b42a008557ed575c1defae332a30b59918695237
b5db0bce6b87a3f772ffd6dbd63bbf16105d518f
84cf0caff405b9410322449b6f95fa0949157224
e5a2677acd7c15f8c20d6cb8357dd4f006ae138c
88190460a76060c27b5de76eb69065d23d85f146
3d5ae9adcbfb3c9722a39e8f421136cf1bae6749
36ee16aeec4d3476dd3ff9394831f0bfb9da1529
ef0b64ecb1f16efa420e122856fe1a43dbab461d
d4b8b70a6c64661f29cb734363e4f87e358f7751